### PR TITLE
Adding tangent and bitangent support to glTFFileLoader and Babylon.js

### DIFF
--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -597,7 +597,7 @@ module BABYLON {
             }
 
             //bitangent aka binormal
-            if (tempVertexData.tangents !== undefined && tempVertexData.tangents !== null) {
+            if (tempVertexData.tangents) {
                 var bitangents: number[] = [];
                 var tindex = 0;
                 for (var i = 0; i < tempVertexData.normals.length; i += 3) {

--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -550,6 +550,10 @@ module BABYLON {
 
                     verticesCounts.push(tempVertexData.positions.length);
                 }
+                else if (semantic === "TANGENT") {
+                    tempVertexData.tangents = new Float32Array(buffer.length);
+                    (<Float32Array>tempVertexData.tangents).set(buffer);
+                }
                 else if (semantic.indexOf("TEXCOORD_") !== -1) {
                     var channel = Number(semantic.split("_")[1]);
                     var uvKind = VertexBuffer.UVKind + (channel === 0 ? "" : (channel + 1));
@@ -590,6 +594,24 @@ module BABYLON {
 
                 tempVertexData.indices = new Int32Array(indices);
                 indexCounts.push(tempVertexData.indices.length);
+            }
+
+            //bitangent aka binormal
+            if (tempVertexData.tangents !== undefined && tempVertexData.tangents !== null) {
+                var bitangents: number[] = [];
+                var tindex = 0;
+                for (var i = 0; i < tempVertexData.normals.length; i += 3) {
+                    var n = Vector3.FromArray(tempVertexData.normals, i);
+                    var t = Vector4.FromArray(tempVertexData.tangents, tindex);
+                    //bitangent cross product of normal and tangent
+                    var bitangent = Vector3.Cross(n, t.toVector3().scale((t.w < 0) ? -1 : 1)).asArray();
+                    bitangents.push(bitangent[0]);
+                    bitangents.push(bitangent[1]);
+                    bitangents.push(bitangent[2]);
+                    tindex += 4;
+                }
+                tempVertexData.bitangents = new Float32Array(bitangents.length);
+                (<Float32Array>tempVertexData.bitangents).set(bitangents);
             }
 
             vertexData.merge(tempVertexData);
@@ -1228,7 +1250,7 @@ module BABYLON {
                     BIN: 0x004E4942
                 }
             };
-            
+
             var binaryReader = new BinaryReader(data);
 
             var magic = binaryReader.readUint32();

--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -595,25 +595,7 @@ module BABYLON {
                 tempVertexData.indices = new Int32Array(indices);
                 indexCounts.push(tempVertexData.indices.length);
             }
-
-            //bitangent aka binormal
-            if (tempVertexData.tangents) {
-                var bitangents: number[] = [];
-                var tindex = 0;
-                for (var i = 0; i < tempVertexData.normals.length; i += 3) {
-                    var n = Vector3.FromArray(tempVertexData.normals, i);
-                    var t = Vector4.FromArray(tempVertexData.tangents, tindex);
-                    //bitangent cross product of normal and tangent
-                    var bitangent = Vector3.Cross(n, t.toVector3().scale((t.w < 0) ? -1 : 1)).asArray();
-                    bitangents.push(bitangent[0]);
-                    bitangents.push(bitangent[1]);
-                    bitangents.push(bitangent[2]);
-                    tindex += 4;
-                }
-                tempVertexData.bitangents = new Float32Array(bitangents.length);
-                (<Float32Array>tempVertexData.bitangents).set(bitangents);
-            }
-
+            
             vertexData.merge(tempVertexData);
             tempVertexData = undefined;
 

--- a/src/Materials/babylon.pbrMaterial.ts
+++ b/src/Materials/babylon.pbrMaterial.ts
@@ -951,7 +951,7 @@
                     if (mesh.isVerticesDataPresent(VertexBuffer.TangentKind)) {
                         this._defines.TANGENT = true;
                     }
-                    if (mesh.isVerticesDataPresent(VertexBuffer.BiTangentKind)) {
+                    if (mesh.isVerticesDataPresent(VertexBuffer.BitangentKind)) {
                         this._defines.BITANGENT = true;
                     }
                 }
@@ -1063,7 +1063,7 @@
                 }
 
                 if (this._defines.BITANGENT) {
-                    attribs.push(VertexBuffer.BiTangentKind);
+                    attribs.push(VertexBuffer.BitangentKind);
                 }
 
                 if (this._defines.UV1) {

--- a/src/Materials/babylon.pbrMaterial.ts
+++ b/src/Materials/babylon.pbrMaterial.ts
@@ -21,6 +21,8 @@
         public EMISSIVEFRESNEL = false;
         public FRESNEL = false;
         public NORMAL = false;
+        public TANGENT = false;
+        public BITANGENT = false; //aka binormal
         public UV1 = false;
         public UV2 = false;
         public VERTEXCOLOR = false;
@@ -946,6 +948,12 @@
             if (mesh) {
                 if (needNormals && mesh.isVerticesDataPresent(VertexBuffer.NormalKind)) {
                     this._defines.NORMAL = true;
+                    if (mesh.isVerticesDataPresent(VertexBuffer.TangentKind)) {
+                        this._defines.TANGENT = true;
+                    }
+                    if (mesh.isVerticesDataPresent(VertexBuffer.BiTangentKind)) {
+                        this._defines.BITANGENT = true;
+                    }
                 }
                 if (needUVs) {
                     if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
@@ -1048,6 +1056,14 @@
 
                 if (this._defines.NORMAL) {
                     attribs.push(VertexBuffer.NormalKind);
+                }
+
+                if (this._defines.TANGENT) {
+                    attribs.push(VertexBuffer.TangentKind);
+                }
+
+                if (this._defines.BITANGENT) {
+                    attribs.push(VertexBuffer.BiTangentKind);
                 }
 
                 if (this._defines.UV1) {

--- a/src/Materials/babylon.pbrMaterial.ts
+++ b/src/Materials/babylon.pbrMaterial.ts
@@ -22,7 +22,6 @@
         public FRESNEL = false;
         public NORMAL = false;
         public TANGENT = false;
-        public BITANGENT = false; //aka binormal
         public UV1 = false;
         public UV2 = false;
         public VERTEXCOLOR = false;
@@ -951,9 +950,6 @@
                     if (mesh.isVerticesDataPresent(VertexBuffer.TangentKind)) {
                         this._defines.TANGENT = true;
                     }
-                    if (mesh.isVerticesDataPresent(VertexBuffer.BitangentKind)) {
-                        this._defines.BITANGENT = true;
-                    }
                 }
                 if (needUVs) {
                     if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
@@ -1060,10 +1056,6 @@
 
                 if (this._defines.TANGENT) {
                     attribs.push(VertexBuffer.TangentKind);
-                }
-
-                if (this._defines.BITANGENT) {
-                    attribs.push(VertexBuffer.BitangentKind);
                 }
 
                 if (this._defines.UV1) {

--- a/src/Materials/babylon.standardMaterial.ts
+++ b/src/Materials/babylon.standardMaterial.ts
@@ -24,6 +24,8 @@
         public EMISSIVEFRESNEL = false;
         public FRESNEL = false;
         public NORMAL = false;
+        public TANGENT = false;
+        public BITANGENT = false; //aka binormal
         public UV1 = false;
         public UV2 = false;
         public VERTEXCOLOR = false;
@@ -547,6 +549,12 @@
             if (mesh) {
                 if (needNormals && mesh.isVerticesDataPresent(VertexBuffer.NormalKind)) {
                     this._defines.NORMAL = true;
+                    if (mesh.isVerticesDataPresent(VertexBuffer.TangentKind)) {
+                        this._defines.TANGENT = true;
+                    }
+                    if (mesh.isVerticesDataPresent(VertexBuffer.BiTangentKind)) {
+                        this._defines.BITANGENT = true;
+                    }
                 }
                 if (needUVs) {
                     if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
@@ -649,6 +657,14 @@
 
                 if (this._defines.NORMAL) {
                     attribs.push(VertexBuffer.NormalKind);
+                }
+
+                if (this._defines.TANGENT) {
+                    attribs.push(VertexBuffer.TangentKind);
+                }
+
+                if (this._defines.BITANGENT) {
+                    attribs.push(VertexBuffer.BiTangentKind);
                 }
 
                 if (this._defines.UV1) {

--- a/src/Materials/babylon.standardMaterial.ts
+++ b/src/Materials/babylon.standardMaterial.ts
@@ -552,7 +552,7 @@
                     if (mesh.isVerticesDataPresent(VertexBuffer.TangentKind)) {
                         this._defines.TANGENT = true;
                     }
-                    if (mesh.isVerticesDataPresent(VertexBuffer.BiTangentKind)) {
+                    if (mesh.isVerticesDataPresent(VertexBuffer.BitangentKind)) {
                         this._defines.BITANGENT = true;
                     }
                 }
@@ -664,7 +664,7 @@
                 }
 
                 if (this._defines.BITANGENT) {
-                    attribs.push(VertexBuffer.BiTangentKind);
+                    attribs.push(VertexBuffer.BitangentKind);
                 }
 
                 if (this._defines.UV1) {

--- a/src/Materials/babylon.standardMaterial.ts
+++ b/src/Materials/babylon.standardMaterial.ts
@@ -25,7 +25,6 @@
         public FRESNEL = false;
         public NORMAL = false;
         public TANGENT = false;
-        public BITANGENT = false; //aka binormal
         public UV1 = false;
         public UV2 = false;
         public VERTEXCOLOR = false;
@@ -552,9 +551,6 @@
                     if (mesh.isVerticesDataPresent(VertexBuffer.TangentKind)) {
                         this._defines.TANGENT = true;
                     }
-                    if (mesh.isVerticesDataPresent(VertexBuffer.BitangentKind)) {
-                        this._defines.BITANGENT = true;
-                    }
                 }
                 if (needUVs) {
                     if (mesh.isVerticesDataPresent(VertexBuffer.UVKind)) {
@@ -661,10 +657,6 @@
 
                 if (this._defines.TANGENT) {
                     attribs.push(VertexBuffer.TangentKind);
-                }
-
-                if (this._defines.BITANGENT) {
-                    attribs.push(VertexBuffer.BitangentKind);
                 }
 
                 if (this._defines.UV1) {

--- a/src/Math/babylon.math.ts
+++ b/src/Math/babylon.math.ts
@@ -2200,7 +2200,7 @@
         /**
          * Returns a new Vector4 set from the starting index of the passed array.  
          */
-        public static FromArray(array: number[], offset?: number): Vector4 {
+        public static FromArray(array: number[]  | Float32Array, offset?: number): Vector4 {
             if (!offset) {
                 offset = 0;
             }
@@ -2209,7 +2209,7 @@
         /**
          * Updates the passed vector "result" from the starting index of the passed array.  
          */
-        public static FromArrayToRef(array: number[], offset: number, result: Vector4): void {
+        public static FromArrayToRef(array: number[] | Float32Array, offset: number, result: Vector4): void {
             result.x = array[offset];
             result.y = array[offset + 1];
             result.z = array[offset + 2];
@@ -2275,7 +2275,6 @@
         /**
          * Returns the squared distance (float) between the vectors "value1" and "value2".  
          */
-        publi
         public static DistanceSquared(value1: Vector4, value2: Vector4): number {
             var x = value1.x - value2.x;
             var y = value1.y - value2.y;
@@ -2291,6 +2290,41 @@
             var center = value1.add(value2);
             center.scaleInPlace(0.5);
             return center;
+        }
+
+        /**
+         * Returns a new Vector4 set with the result of the normal transformation by the passed matrix of the passed vector.  
+         * This methods computes transformed normalized direction vectors only.  
+         */
+        public static TransformNormal(vector: Vector4, transformation: Matrix): Vector4 {
+            var result = Vector4.Zero();
+            Vector4.TransformNormalToRef(vector, transformation, result);
+            return result;
+        }
+
+        /**
+         * Sets the passed vector "result" with the result of the normal transformation by the passed matrix of the passed vector.  
+         * This methods computes transformed normalized direction vectors only. 
+         */
+        public static TransformNormalToRef(vector: Vector4, transformation: Matrix, result: Vector4): void {
+            var x = (vector.x * transformation.m[0]) + (vector.y * transformation.m[4]) + (vector.z * transformation.m[8]);
+            var y = (vector.x * transformation.m[1]) + (vector.y * transformation.m[5]) + (vector.z * transformation.m[9]);
+            var z = (vector.x * transformation.m[2]) + (vector.y * transformation.m[6]) + (vector.z * transformation.m[10]);
+            result.x = x;
+            result.y = y;
+            result.z = z;
+            result.w = vector.w;
+        }
+
+        /**
+         * Sets the passed vector "result" with the result of the normal transformation by the passed matrix of the passed floats (x, y, z, w).  
+         * This methods computes transformed normalized direction vectors only. 
+         */
+        public static TransformNormalFromFloatsToRef(x: number, y: number, z: number, w: number, transformation: Matrix, result: Vector4): void {
+            result.x = (x * transformation.m[0]) + (y * transformation.m[4]) + (z * transformation.m[8]);
+            result.y = (x * transformation.m[1]) + (y * transformation.m[5]) + (z * transformation.m[9]);
+            result.z = (x * transformation.m[2]) + (y * transformation.m[6]) + (z * transformation.m[10]);
+            result.w = w;
         }
     }
 

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1,7 +1,8 @@
 ﻿module BABYLON {
     export type IndicesArray = number[] | Int32Array | Uint32Array | Uint16Array;
 
-    export interface IGetSetVerticesData {
+    export interface IGetSetVerticesData
+    {
         isVerticesDataPresent(kind: string): boolean;
         getVerticesData(kind: string, copyWhenShared?: boolean): number[] | Float32Array;
         getIndices(copyWhenShared?: boolean): IndicesArray;
@@ -39,7 +40,7 @@
                 case VertexBuffer.TangentKind:
                     this.tangents = data;
                     break;
-                case VertexBuffer.BiTangentKind:
+                case VertexBuffer.BitangentKind:
                     this.bitangents = data;
                     break;
                 case VertexBuffer.UVKind:
@@ -130,7 +131,7 @@
             }
 
             if (this.bitangents) {
-                meshOrGeometry.setVerticesData(VertexBuffer.BiTangentKind, this.bitangents, updatable);
+                meshOrGeometry.setVerticesData(VertexBuffer.BitangentKind, this.bitangents, updatable);
             }
 
             if (this.uvs) {
@@ -197,7 +198,7 @@
             }
 
             if (this.bitangents) {
-                meshOrGeometry.updateVerticesData(VertexBuffer.BiTangentKind, this.bitangents, updateExtends, makeItUnique);
+                meshOrGeometry.updateVerticesData(VertexBuffer.BitangentKind, this.bitangents, updateExtends, makeItUnique);
             }
 
             if (this.uvs) {
@@ -482,8 +483,8 @@
                 result.tangents = meshOrGeometry.getVerticesData(VertexBuffer.TangentKind, copyWhenShared);
             }
 
-            if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.BiTangentKind)) {
-                result.bitangents = meshOrGeometry.getVerticesData(VertexBuffer.BiTangentKind, copyWhenShared);
+            if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.BitangentKind)) {
+                result.bitangents = meshOrGeometry.getVerticesData(VertexBuffer.BitangentKind, copyWhenShared);
             }
 
             if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.UVKind)) {
@@ -2393,7 +2394,7 @@
             // bitangents
             var bitangents = parsedVertexData.bitangents;
             if (bitangents) {
-                vertexData.set(bitangents, VertexBuffer.BiTangentKind);
+                vertexData.set(bitangents, VertexBuffer.BitangentKind);
             }
 
             // uvs

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -1,8 +1,7 @@
 ﻿module BABYLON {
     export type IndicesArray = number[] | Int32Array | Uint32Array | Uint16Array;
 
-    export interface IGetSetVerticesData
-    {
+    export interface IGetSetVerticesData {
         isVerticesDataPresent(kind: string): boolean;
         getVerticesData(kind: string, copyWhenShared?: boolean): number[] | Float32Array;
         getIndices(copyWhenShared?: boolean): IndicesArray;
@@ -14,6 +13,8 @@
     export class VertexData {
         public positions: number[] | Float32Array;
         public normals: number[] | Float32Array;
+        public tangents: number[] | Float32Array;
+        public bitangents: number[] | Float32Array;
         public uvs: number[] | Float32Array;
         public uvs2: number[] | Float32Array;
         public uvs3: number[] | Float32Array;
@@ -34,6 +35,12 @@
                     break;
                 case VertexBuffer.NormalKind:
                     this.normals = data;
+                    break;
+                case VertexBuffer.TangentKind:
+                    this.tangents = data;
+                    break;
+                case VertexBuffer.BiTangentKind:
+                    this.bitangents = data;
                     break;
                 case VertexBuffer.UVKind:
                     this.uvs = data;
@@ -118,6 +125,14 @@
                 meshOrGeometry.setVerticesData(VertexBuffer.NormalKind, this.normals, updatable);
             }
 
+            if (this.tangents) {
+                meshOrGeometry.setVerticesData(VertexBuffer.TangentKind, this.tangents, updatable);
+            }
+
+            if (this.bitangents) {
+                meshOrGeometry.setVerticesData(VertexBuffer.BiTangentKind, this.bitangents, updatable);
+            }
+
             if (this.uvs) {
                 meshOrGeometry.setVerticesData(VertexBuffer.UVKind, this.uvs, updatable);
             }
@@ -175,6 +190,14 @@
 
             if (this.normals) {
                 meshOrGeometry.updateVerticesData(VertexBuffer.NormalKind, this.normals, updateExtends, makeItUnique);
+            }
+
+            if (this.tangents) {
+                meshOrGeometry.updateVerticesData(VertexBuffer.TangentKind, this.tangents, updateExtends, makeItUnique);
+            }
+
+            if (this.bitangents) {
+                meshOrGeometry.updateVerticesData(VertexBuffer.BiTangentKind, this.bitangents, updateExtends, makeItUnique);
             }
 
             if (this.uvs) {
@@ -259,6 +282,35 @@
                     this.normals[index + 2] = transformed.z;
                 }
             }
+
+            if (this.tangents) {
+                var tangent = Vector4.Zero();
+                var tangentTransformed = Vector4.Zero();
+
+                for (index = 0; index < this.tangents.length; index += 4) {
+                    Vector4.FromArrayToRef(this.tangents, index, tangent);
+
+                    Vector4.TransformNormalToRef(tangent, matrix, tangentTransformed);
+                    this.tangents[index] = tangentTransformed.x;
+                    this.tangents[index + 1] = tangentTransformed.y;
+                    this.tangents[index + 2] = tangentTransformed.z;
+                    this.tangents[index + 3] = tangentTransformed.w;
+                }
+            }
+
+            if (this.bitangents) {
+                var bitangent = Vector3.Zero();
+
+                for (index = 0; index < this.bitangents.length; index += 3) {
+                    Vector3.FromArrayToRef(this.bitangents, index, bitangent);
+
+                    Vector3.TransformNormalToRef(bitangent, matrix, transformed);
+                    this.bitangents[index] = transformed.x;
+                    this.bitangents[index + 1] = transformed.y;
+                    this.bitangents[index + 2] = transformed.z;
+                }
+            }
+
             return this;
         }
 
@@ -281,6 +333,8 @@
 
             this.positions = this._mergeElement(this.positions, other.positions);
             this.normals = this._mergeElement(this.normals, other.normals);
+            this.tangents = this._mergeElement(this.tangents, other.tangents);
+            this.bitangents = this._mergeElement(this.bitangents, other.bitangents);
             this.uvs = this._mergeElement(this.uvs, other.uvs);
             this.uvs2 = this._mergeElement(this.uvs2, other.uvs2);
             this.uvs3 = this._mergeElement(this.uvs3, other.uvs3);
@@ -337,6 +391,14 @@
 
             if (this.normals) {
                 serializationObject.normals = this.normals;
+            }
+
+            if (this.tangents) {
+                serializationObject.tangents = this.tangents;
+            }
+
+            if (this.bitangents) {
+                serializationObject.bitangents = this.bitangents;
             }
 
             if (this.uvs) {
@@ -414,6 +476,14 @@
 
             if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.NormalKind)) {
                 result.normals = meshOrGeometry.getVerticesData(VertexBuffer.NormalKind, copyWhenShared);
+            }
+
+            if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.TangentKind)) {
+                result.tangents = meshOrGeometry.getVerticesData(VertexBuffer.TangentKind, copyWhenShared);
+            }
+
+            if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.BiTangentKind)) {
+                result.bitangents = meshOrGeometry.getVerticesData(VertexBuffer.BiTangentKind, copyWhenShared);
             }
 
             if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.UVKind)) {
@@ -2061,7 +2131,7 @@
          * bbSize : optional bounding box size data, required for facetPartitioning computation
          * bInfo : optional bounding info, required for facetPartitioning computation
          */
-        public static ComputeNormals(positions: any, indices: any, normals: any, 
+        public static ComputeNormals(positions: any, indices: any, normals: any,
             options?: { facetNormals?: any, facetPositions?: any, facetPartitioning?: any, ratio?: number, bInfo?: any, bbSize?: Vector3, subDiv?: any}): void {
 
             // temporary scalar variables
@@ -2095,7 +2165,7 @@
             }
 
             // facetPartitioning reinit if needed
-            if (computeFacetPartitioning) {  
+            if (computeFacetPartitioning) {
                 var ox = 0;                 // X partitioning index for facet position
                 var oy = 0;                 // Y partinioning index for facet position
                 var oz = 0;                 // Z partinioning index for facet position
@@ -2121,7 +2191,7 @@
                 var subSq = options.subDiv.max * options.subDiv.max;
                 options.facetPartitioning.length = 0;
             }
-        
+
             // reset the normals
             for (index = 0; index < positions.length; index++) {
                 normals[index] = 0.0;
@@ -2140,7 +2210,7 @@
                 v2z = v2x + 2;
                 v3x = indices[index * 3 + 2] * 3;
                 v3y = v3x + 1;
-                v3z = v3x + 2;        
+                v3z = v3x + 2;
 
                 p1p2x = positions[v1x] - positions[v2x];          // compute two vectors per facet : p1p2 and p3p2
                 p1p2y = positions[v1y] - positions[v2y];
@@ -2151,7 +2221,7 @@
                 p3p2z = positions[v3z] - positions[v2z];
 
                 // compute the face normal with the cross product
-                faceNormalx = p1p2y * p3p2z - p1p2z * p3p2y;            
+                faceNormalx = p1p2y * p3p2z - p1p2z * p3p2y;
                 faceNormaly = p1p2z * p3p2x - p1p2x * p3p2z;
                 faceNormalz = p1p2x * p3p2y - p1p2y * p3p2x;
                 // normalize this normal and store it in the array facetData
@@ -2162,7 +2232,7 @@
                 faceNormalz /= length;
 
                 if (computeFacetNormals) {
-                    options.facetNormals[index].x = faceNormalx;                                  
+                    options.facetNormals[index].x = faceNormalx;
                     options.facetNormals[index].y = faceNormaly;
                     options.facetNormals[index].z = faceNormalz;
                 }
@@ -2189,7 +2259,7 @@
                     b3x = Math.floor((positions[v3x] - options.bInfo.minimum.x * options.ratio) * xSubRatio);
                     b3y = Math.floor((positions[v3y] - options.bInfo.minimum.y * options.ratio) * ySubRatio);
                     b3z = Math.floor((positions[v3z] - options.bInfo.minimum.z * options.ratio) * zSubRatio);
-                    
+
                     block_idx_v1 = b1x + options.subDiv.max * b1y + subSq * b1z;
                     block_idx_v2 = b2x + options.subDiv.max * b2y + subSq * b2z;
                     block_idx_v3 = b3x + options.subDiv.max * b3y + subSq * b3z;
@@ -2209,7 +2279,7 @@
                         options.facetPartitioning[block_idx_v3].push(index);
                     }
                     if (!(block_idx_o == block_idx_v1 || block_idx_o == block_idx_v2 || block_idx_o == block_idx_v3)) {
-                        options.facetPartitioning[block_idx_o].push(index); 
+                        options.facetPartitioning[block_idx_o].push(index);
                     }
                 }
 
@@ -2312,6 +2382,18 @@
             var normals = parsedVertexData.normals;
             if (normals) {
                 vertexData.set(normals, VertexBuffer.NormalKind);
+            }
+
+            // tangents
+            var tangents = parsedVertexData.tangents;
+            if (tangents) {
+                vertexData.set(tangents, VertexBuffer.TangentKind);
+            }
+
+            // bitangents
+            var bitangents = parsedVertexData.bitangents;
+            if (bitangents) {
+                vertexData.set(bitangents, VertexBuffer.BiTangentKind);
             }
 
             // uvs

--- a/src/Mesh/babylon.mesh.vertexData.ts
+++ b/src/Mesh/babylon.mesh.vertexData.ts
@@ -15,7 +15,6 @@
         public positions: number[] | Float32Array;
         public normals: number[] | Float32Array;
         public tangents: number[] | Float32Array;
-        public bitangents: number[] | Float32Array;
         public uvs: number[] | Float32Array;
         public uvs2: number[] | Float32Array;
         public uvs3: number[] | Float32Array;
@@ -39,9 +38,6 @@
                     break;
                 case VertexBuffer.TangentKind:
                     this.tangents = data;
-                    break;
-                case VertexBuffer.BitangentKind:
-                    this.bitangents = data;
                     break;
                 case VertexBuffer.UVKind:
                     this.uvs = data;
@@ -130,10 +126,6 @@
                 meshOrGeometry.setVerticesData(VertexBuffer.TangentKind, this.tangents, updatable);
             }
 
-            if (this.bitangents) {
-                meshOrGeometry.setVerticesData(VertexBuffer.BitangentKind, this.bitangents, updatable);
-            }
-
             if (this.uvs) {
                 meshOrGeometry.setVerticesData(VertexBuffer.UVKind, this.uvs, updatable);
             }
@@ -195,10 +187,6 @@
 
             if (this.tangents) {
                 meshOrGeometry.updateVerticesData(VertexBuffer.TangentKind, this.tangents, updateExtends, makeItUnique);
-            }
-
-            if (this.bitangents) {
-                meshOrGeometry.updateVerticesData(VertexBuffer.BitangentKind, this.bitangents, updateExtends, makeItUnique);
             }
 
             if (this.uvs) {
@@ -299,19 +287,6 @@
                 }
             }
 
-            if (this.bitangents) {
-                var bitangent = Vector3.Zero();
-
-                for (index = 0; index < this.bitangents.length; index += 3) {
-                    Vector3.FromArrayToRef(this.bitangents, index, bitangent);
-
-                    Vector3.TransformNormalToRef(bitangent, matrix, transformed);
-                    this.bitangents[index] = transformed.x;
-                    this.bitangents[index + 1] = transformed.y;
-                    this.bitangents[index + 2] = transformed.z;
-                }
-            }
-
             return this;
         }
 
@@ -335,7 +310,6 @@
             this.positions = this._mergeElement(this.positions, other.positions);
             this.normals = this._mergeElement(this.normals, other.normals);
             this.tangents = this._mergeElement(this.tangents, other.tangents);
-            this.bitangents = this._mergeElement(this.bitangents, other.bitangents);
             this.uvs = this._mergeElement(this.uvs, other.uvs);
             this.uvs2 = this._mergeElement(this.uvs2, other.uvs2);
             this.uvs3 = this._mergeElement(this.uvs3, other.uvs3);
@@ -396,10 +370,6 @@
 
             if (this.tangents) {
                 serializationObject.tangents = this.tangents;
-            }
-
-            if (this.bitangents) {
-                serializationObject.bitangents = this.bitangents;
             }
 
             if (this.uvs) {
@@ -481,10 +451,6 @@
 
             if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.TangentKind)) {
                 result.tangents = meshOrGeometry.getVerticesData(VertexBuffer.TangentKind, copyWhenShared);
-            }
-
-            if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.BitangentKind)) {
-                result.bitangents = meshOrGeometry.getVerticesData(VertexBuffer.BitangentKind, copyWhenShared);
             }
 
             if (meshOrGeometry.isVerticesDataPresent(VertexBuffer.UVKind)) {
@@ -2389,12 +2355,6 @@
             var tangents = parsedVertexData.tangents;
             if (tangents) {
                 vertexData.set(tangents, VertexBuffer.TangentKind);
-            }
-
-            // bitangents
-            var bitangents = parsedVertexData.bitangents;
-            if (bitangents) {
-                vertexData.set(bitangents, VertexBuffer.BitangentKind);
             }
 
             // uvs

--- a/src/Mesh/babylon.vertexBuffer.ts
+++ b/src/Mesh/babylon.vertexBuffer.ts
@@ -14,7 +14,7 @@
                     case VertexBuffer.PositionKind:
                         stride = 3;
                         break;
-                    case VertexBuffer.BiTangentKind:
+                    case VertexBuffer.BitangentKind:
                     case VertexBuffer.NormalKind:
                         stride = 3;
                         break;
@@ -157,7 +157,7 @@
         private static _PositionKind = "position";
         private static _NormalKind = "normal";
         private static _TangentKind = "tangent";
-        private static _BiTangentKind = "bitangent";
+        private static _BitangentKind = "bitangent";
         private static _UVKind = "uv";
         private static _UV2Kind = "uv2";
         private static _UV3Kind = "uv3";
@@ -182,8 +182,8 @@
             return VertexBuffer._TangentKind;
         }
 
-        public static get BiTangentKind(): string {
-            return VertexBuffer._BiTangentKind;
+        public static get BitangentKind(): string {
+            return VertexBuffer._BitangentKind;
         }
 
         public static get UVKind(): string {

--- a/src/Mesh/babylon.vertexBuffer.ts
+++ b/src/Mesh/babylon.vertexBuffer.ts
@@ -14,6 +14,7 @@
                     case VertexBuffer.PositionKind:
                         stride = 3;
                         break;
+                    case VertexBuffer.BiTangentKind:
                     case VertexBuffer.NormalKind:
                         stride = 3;
                         break;
@@ -25,6 +26,7 @@
                     case VertexBuffer.UV6Kind:
                         stride = 2;
                         break;
+                    case VertexBuffer.TangentKind:
                     case VertexBuffer.ColorKind:
                         stride = 4;
                         break;
@@ -154,6 +156,8 @@
         // Enums
         private static _PositionKind = "position";
         private static _NormalKind = "normal";
+        private static _TangentKind = "tangent";
+        private static _BiTangentKind = "bitangent";
         private static _UVKind = "uv";
         private static _UV2Kind = "uv2";
         private static _UV3Kind = "uv3";
@@ -172,6 +176,14 @@
 
         public static get NormalKind(): string {
             return VertexBuffer._NormalKind;
+        }
+
+        public static get TangentKind(): string {
+            return VertexBuffer._TangentKind;
+        }
+
+        public static get BiTangentKind(): string {
+            return VertexBuffer._BiTangentKind;
         }
 
         public static get UVKind(): string {

--- a/src/Mesh/babylon.vertexBuffer.ts
+++ b/src/Mesh/babylon.vertexBuffer.ts
@@ -14,7 +14,6 @@
                     case VertexBuffer.PositionKind:
                         stride = 3;
                         break;
-                    case VertexBuffer.BitangentKind:
                     case VertexBuffer.NormalKind:
                         stride = 3;
                         break;
@@ -157,7 +156,6 @@
         private static _PositionKind = "position";
         private static _NormalKind = "normal";
         private static _TangentKind = "tangent";
-        private static _BitangentKind = "bitangent";
         private static _UVKind = "uv";
         private static _UV2Kind = "uv2";
         private static _UV3Kind = "uv3";
@@ -180,10 +178,6 @@
 
         public static get TangentKind(): string {
             return VertexBuffer._TangentKind;
-        }
-
-        public static get BitangentKind(): string {
-            return VertexBuffer._BitangentKind;
         }
 
         public static get UVKind(): string {

--- a/src/Shaders/ShadersInclude/bumpFragment.fx
+++ b/src/Shaders/ShadersInclude/bumpFragment.fx
@@ -1,7 +1,11 @@
 ﻿vec2 uvOffset = vec2(0.0, 0.0);
 
 #if defined(BUMP) || defined(PARALLAX)
-	mat3 TBN = cotangent_frame(normalW * vBumpInfos.y, -viewDirectionW, vBumpUV);
+	#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL)
+		mat3 TBN = vTBN;
+	#else
+		mat3 TBN = cotangent_frame(normalW * vBumpInfos.y, -viewDirectionW, vBumpUV);
+	#endif
 #endif
 
 #ifdef PARALLAX

--- a/src/Shaders/ShadersInclude/bumpFragment.fx
+++ b/src/Shaders/ShadersInclude/bumpFragment.fx
@@ -1,7 +1,7 @@
 ﻿vec2 uvOffset = vec2(0.0, 0.0);
 
 #if defined(BUMP) || defined(PARALLAX)
-	#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL)
+	#if defined(TANGENT) && defined(NORMAL)
 		mat3 TBN = vTBN;
 	#else
 		mat3 TBN = cotangent_frame(normalW * vBumpInfos.y, -viewDirectionW, vBumpUV);

--- a/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
+++ b/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
@@ -2,6 +2,9 @@
 	varying vec2 vBumpUV;
 	uniform vec3 vBumpInfos;
 	uniform sampler2D bumpSampler;
+#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL) 
+	varying mat3 vTBN;
+#endif
 
 	// Thanks to http://www.thetenthplanet.de/archives/1180
 	mat3 cotangent_frame(vec3 normal, vec3 p, vec2 uv)

--- a/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
+++ b/src/Shaders/ShadersInclude/bumpFragmentFunctions.fx
@@ -2,7 +2,7 @@
 	varying vec2 vBumpUV;
 	uniform vec3 vBumpInfos;
 	uniform sampler2D bumpSampler;
-#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL) 
+#if defined(TANGENT) && defined(NORMAL) 
 	varying mat3 vTBN;
 #endif
 

--- a/src/Shaders/ShadersInclude/bumpVertex.fx
+++ b/src/Shaders/ShadersInclude/bumpVertex.fx
@@ -1,0 +1,5 @@
+#if defined(BUMP) || defined(PARALLAX)
+	#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL) 
+		vTBN = mat3(tangent.xyz, bitangent, normal);
+	#endif
+#endif

--- a/src/Shaders/ShadersInclude/bumpVertex.fx
+++ b/src/Shaders/ShadersInclude/bumpVertex.fx
@@ -1,5 +1,8 @@
 #if defined(BUMP) || defined(PARALLAX)
 	#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL) 
 		vTBN = mat3(tangent.xyz, bitangent, normal);
+	#elif defined(TANGENT) && defined(NORMAL) 
+		vec3 bitangent = cross(normal, tangent.xyz) * ((tangent.w < 0.0) ? -1.0 : 1.0);
+		vTBN = mat3(tangent.xyz, bitangent, normal);
 	#endif
 #endif

--- a/src/Shaders/ShadersInclude/bumpVertex.fx
+++ b/src/Shaders/ShadersInclude/bumpVertex.fx
@@ -1,8 +1,6 @@
 #if defined(BUMP) || defined(PARALLAX)
-	#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL) 
-		vTBN = mat3(tangent.xyz, bitangent, normal);
-	#elif defined(TANGENT) && defined(NORMAL) 
-		vec3 bitangent = cross(normal, tangent.xyz) * ((tangent.w < 0.0) ? -1.0 : 1.0);
+	#if defined(TANGENT) && defined(NORMAL) 
+		vec3 bitangent = cross(normal, tangent.xyz) * sign(tangent.w); //aka binormal
 		vTBN = mat3(tangent.xyz, bitangent, normal);
 	#endif
 #endif

--- a/src/Shaders/ShadersInclude/bumpVertexDeclaration.fx
+++ b/src/Shaders/ShadersInclude/bumpVertexDeclaration.fx
@@ -1,5 +1,5 @@
 #if defined(BUMP) || defined(PARALLAX)
-	#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL) 
+	#if defined(TANGENT) && defined(NORMAL) 
 		varying mat3 vTBN;
 	#endif
 #endif

--- a/src/Shaders/ShadersInclude/bumpVertexDeclaration.fx
+++ b/src/Shaders/ShadersInclude/bumpVertexDeclaration.fx
@@ -1,0 +1,5 @@
+#if defined(BUMP) || defined(PARALLAX)
+	#if defined(TANGENT) && defined(BITANGENT) && defined(NORMAL) 
+		varying mat3 vTBN;
+	#endif
+#endif

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -6,9 +6,6 @@ attribute vec3 normal;
 #ifdef TANGENT
 attribute vec4 tangent;
 #endif
-#ifdef BITANGENT
-attribute vec3 bitangent; //aka binormal
-#endif
 #ifdef UV1
 attribute vec2 uv;
 #endif

--- a/src/Shaders/default.vertex.fx
+++ b/src/Shaders/default.vertex.fx
@@ -3,6 +3,12 @@ attribute vec3 position;
 #ifdef NORMAL
 attribute vec3 normal;
 #endif
+#ifdef TANGENT
+attribute vec4 tangent;
+#endif
+#ifdef BITANGENT
+attribute vec3 bitangent; //aka binormal
+#endif
 #ifdef UV1
 attribute vec2 uv;
 #endif
@@ -74,6 +80,8 @@ varying vec3 vNormalW;
 #ifdef VERTEXCOLOR
 varying vec4 vColor;
 #endif
+
+#include<bumpVertexDeclaration>
 
 #include<clipPlaneVertexDeclaration>
 
@@ -196,6 +204,7 @@ void main(void) {
 	}
 #endif
 
+#include<bumpVertex>
 #include<clipPlaneVertex>
 #include<fogVertex>
 #include<shadowsVertex>[0..maxSimultaneousLights]

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -5,6 +5,12 @@ attribute vec3 position;
 #ifdef NORMAL
 attribute vec3 normal;
 #endif
+#ifdef TANGENT
+attribute vec4 tangent;
+#endif
+#ifdef BITANGENT
+attribute vec3 bitangent; //aka binormal
+#endif
 #ifdef UV1
 attribute vec2 uv;
 #endif
@@ -79,7 +85,7 @@ varying vec3 vNormalW;
 varying vec4 vColor;
 #endif
 
-
+#include<bumpVertexDeclaration>
 #include<clipPlaneVertexDeclaration>
 #include<fogVertexDeclaration>
 #include<shadowsVertexDeclaration>[0..maxSimultaneousLights]
@@ -199,6 +205,9 @@ void main(void) {
         vBumpUV = vec2(bumpMatrix * vec4(uv2, 1.0, 0.0));
     }
 #endif
+
+    // TBN
+#include<bumpVertex>
 
     // Clip plane
 #include<clipPlaneVertex>

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -85,6 +85,7 @@ varying vec3 vNormalW;
 varying vec4 vColor;
 #endif
 
+
 #include<bumpVertexDeclaration>
 #include<clipPlaneVertexDeclaration>
 #include<fogVertexDeclaration>

--- a/src/Shaders/pbr.vertex.fx
+++ b/src/Shaders/pbr.vertex.fx
@@ -8,9 +8,6 @@ attribute vec3 normal;
 #ifdef TANGENT
 attribute vec4 tangent;
 #endif
-#ifdef BITANGENT
-attribute vec3 bitangent; //aka binormal
-#endif
 #ifdef UV1
 attribute vec2 uv;
 #endif


### PR DESCRIPTION
- Added tangent support to glTFFileLoader
- Added bitangent calc to glTFFileLoader
- Added tangent/bitangent support to pbrMaterials and standardMaterials
- Added transformation for Vector4 in babylon.math.ts
- Added tangent and bitangent support to babylon.mesh.vertexData and babylon.vertexBuffer
- Created bumpVertex and bumpVertexDelaration to shaderIncludes
- Added bumpVertex* support to pbr and standard shaders