### PR TITLE
Update to glTF loader to support 2.0 animations

### DIFF
--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -147,10 +147,6 @@ module BABYLON {
                         }
                         else if (targetPath === "rotationQuaternion") {
                             rotationQuaternion = value;
-                            // // Y is Up
-                            // if (GLTFFileLoader.MakeYUP) {
-                            //     rotationQuaternion = rotationQuaternion.multiply(new Quaternion(-0.707107, 0, 0, 0.707107));
-                            // }
                         }
                         else {
                             scaling = value;
@@ -720,7 +716,6 @@ module BABYLON {
             node.babylonNode = dummy;
             babylonNode = dummy;
         }
-        // end do this
 
         if (babylonNode !== null) {
             configureNode(babylonNode, node);
@@ -758,7 +753,6 @@ module BABYLON {
                 newNode.parent = parent;
             }
         }
-        // end do this
 
         if (node.children) {
             for (var i = 0; i < node.children.length; i++) {

--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -68,7 +68,8 @@ module BABYLON {
                 var bufferOutput = GLTFUtils.GetBufferFromAccessor(runtime, runtime.gltf.accessors[outputData]);
 
                 var targetID = channel.target.node;
-                var targetNode: any = runtime.gltf.nodes[channel.target.node].babylonNode;
+                var targetNode: any = runtime.babylonScene.getNodeByID("node" + targetID);
+
                 if (targetNode === null) {
                     Tools.Warn("Creating animation index " + animationIndex + " but cannot find node index " + targetID + " to attach to");
                     continue;
@@ -146,6 +147,10 @@ module BABYLON {
                         }
                         else if (targetPath === "rotationQuaternion") {
                             rotationQuaternion = value;
+                            // // Y is Up
+                            // if (GLTFFileLoader.MakeYUP) {
+                            //     rotationQuaternion = rotationQuaternion.multiply(new Quaternion(-0.707107, 0, 0, 0.707107));
+                            // }
                         }
                         else {
                             scaling = value;
@@ -193,7 +198,7 @@ module BABYLON {
             mat = Matrix.Compose(scale, rotation, position);
         }
         else {
-            mat = Matrix.FromArray(node.matrix);
+            mat = Matrix.FromArray(node.matrix || [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0]);
         }
 
         return mat;
@@ -202,41 +207,38 @@ module BABYLON {
     /**
     * Returns the parent bone
     */
-    var getParentBone = (runtime: IGLTFRuntime, skin: IGLTFSkin, jointName: string, newSkeleton: Skeleton): Bone => {
-        // TODO: animation schema broken
-        /*
+    var getParentBone = (runtime: IGLTFRuntime, skin: IGLTFSkin, nodeID: number, newSkeleton: Skeleton): Bone => {
         // Try to find
+        var nodeStringID = "node" + nodeID;
         for (var i = 0; i < newSkeleton.bones.length; i++) {
-            if (newSkeleton.bones[i].name === jointName) {
-                return newSkeleton.bones[i];
+            if (newSkeleton.bones[i].id === nodeStringID) {
+                return newSkeleton.bones[i].getParent();
             }
         }
 
         // Not found, search in gltf nodes
-        var nodes = runtime.gltf.nodes;
-        for (var nde in nodes) {
-            var node: IGLTFNode = nodes[nde];
+        var joints = skin.joints;
+        for (var j = 0; j < joints.length; j++) {
+            var parentID = joints[j];
+            var parent = runtime.gltf.nodes[parentID];
 
-            if (!node.jointName) {
-                continue;
-            }
-
-            var children = node.children;
+            var children = parent.children;
             for (var i = 0; i < children.length; i++) {
-                var child: IGLTFNode = runtime.gltf.nodes[children[i]];
-                if (!child.jointName) {
+                var childID = children[i];
+                var child = runtime.gltf.nodes[childID];
+                if (!nodeIsInJoints(skin, childID)) {
                     continue;
                 }
 
-                if (child.jointName === jointName) {
-                    var mat = configureBoneTransformation(node);
-                    var bone = new Bone(node.name, newSkeleton, getParentBone(runtime, skin, node.jointName, newSkeleton), mat);
-                    bone.id = nde;
+                if (childID === nodeID)
+                {
+                    var mat = configureBoneTransformation(parent);
+                    var bone = new Bone(parent.name || "node" + parentID, newSkeleton, getParentBone(runtime, skin, parentID, newSkeleton), mat);
+                    bone.id = "node" + parentID;
                     return bone;
                 }
             }
         }
-        */
 
         return null;
     }
@@ -244,49 +246,34 @@ module BABYLON {
     /**
     * Returns the appropriate root node
     */
-    var getNodeToRoot = (nodesToRoot: INodeToRoot[], id: string): Bone => {
-        // TODO: animation schema broken
-        /*
+    var getNodeToRoot = (nodesToRoot: INodeToRoot[], id: number): Bone => {
         for (var i = 0; i < nodesToRoot.length; i++) {
             var nodeToRoot = nodesToRoot[i];
 
-            for (var j = 0; j < nodeToRoot.node.children.length; j++) {
-                var child = nodeToRoot.node.children[j];
-                if (child === id) {
-                    return nodeToRoot.bone;
+            if (nodeToRoot.node.children) {
+                for (var j = 0; j < nodeToRoot.node.children.length; j++) {
+                    var child = nodeToRoot.node.children[j];
+                    if (child === id) {
+                        return nodeToRoot.bone;
+                    }
                 }
             }
         }
-        */
 
         return null;
     };
 
     /**
-    * Returns the node with the joint name
+    * Returns the node with the node index
     */
-    var getJointNode = (runtime: IGLTFRuntime, jointName: string): IJointNode => {
-        // TODO: animation schema broken
-        /*
-        var nodes = runtime.nodes;
-        var node: IGLTFNode = nodes[jointName];
+    var getJointNode = (runtime: IGLTFRuntime, nodeID: number): IJointNode => {
+        var node = runtime.gltf.nodes[nodeID];
         if (node) {
             return {
                 node: node,
-                id: jointName
+                id: nodeID
             };
         }
-
-        for (var nde in nodes) {
-            node = nodes[nde];
-            if (node.jointName === jointName) {
-                return {
-                    node: node,
-                    id: nde
-                };
-            }
-        }
-        */
 
         return null;
     }
@@ -294,15 +281,12 @@ module BABYLON {
     /**
     * Checks if a nodes is in joints
     */
-    var nodeIsInJoints = (skin: IGLTFSkin, id: string): boolean => {
-        // TODO: animation schema broken
-        /*
-        for (var i = 0; i < skin.jointNames.length; i++) {
-            if (skin.jointNames[i] === id) {
+    var nodeIsInJoints = (skin: IGLTFSkin, id: number): boolean => {
+        for (var i = 0; i < skin.joints.length; i++) {
+            if (skin.joints[i] === id) {
                 return true;
             }
         }
-        */
 
         return false;
     }
@@ -311,22 +295,19 @@ module BABYLON {
     * Fills the nodes to root for bones and builds hierarchy
     */
     var getNodesToRoot = (runtime: IGLTFRuntime, newSkeleton: Skeleton, skin: IGLTFSkin, nodesToRoot: INodeToRoot[]): void => {
-        // TODO: animation schema broken
-        /*
         // Creates nodes for root
-        for (var nde in runtime.nodes) {
-            var node: IGLTFNode = runtime.nodes[nde];
-            var id = nde;
+        for (var i = 0; i < runtime.gltf.nodes.length; i++) {
+            var node = runtime.gltf.nodes[i];
 
-            if (!node.jointName || nodeIsInJoints(skin, node.jointName)) {
+            if (nodeIsInJoints(skin, i)) {
                 continue;
             }
 
             // Create node to root bone
             var mat = configureBoneTransformation(node);
-            var bone = new Bone(node.name, newSkeleton, null, mat);
-            bone.id = id;
-            nodesToRoot.push({ bone: bone, node: node, id: id });
+            var bone = new Bone(node.name || "node" + i, newSkeleton, null, mat);
+            bone.id = "node" + i;
+            nodesToRoot.push({ bone: bone, node: node, id: i });
         }
 
         // Parenting
@@ -334,69 +315,70 @@ module BABYLON {
             var nodeToRoot = nodesToRoot[i];
             var children = nodeToRoot.node.children;
 
-            for (var j = 0; j < children.length; j++) {
-                var child: INodeToRoot = null;
+            if (children) {
+                for (var j = 0; j < children.length; j++) {
+                    var child: INodeToRoot = null;
 
-                for (var k = 0; k < nodesToRoot.length; k++) {
-                    if (nodesToRoot[k].id === children[j]) {
-                        child = nodesToRoot[k];
-                        break;
+                    for (var k = 0; k < nodesToRoot.length; k++) {
+                        if (nodesToRoot[k].id === children[j]) {
+                            child = nodesToRoot[k];
+                            break;
+                        }
                     }
-                }
 
-                if (child) {
-                    (<any>child.bone)._parent = nodeToRoot.bone;
-                    nodeToRoot.bone.children.push(child.bone);
+                    if (child) {
+                        (<any>child.bone)._parent = nodeToRoot.bone;
+                        nodeToRoot.bone.children.push(child.bone);
+                    }
                 }
             }
         }
-        */
     };
 
     /**
     * Imports a skeleton
     */
-    var importSkeleton = (runtime: IGLTFRuntime, skin: IGLTFSkin, mesh: Mesh, newSkeleton: Skeleton, index: number): Skeleton => {
-        // TODO: animation schema broken
-        return null;
-        /*
-        if (!newSkeleton) {
-            newSkeleton = new Skeleton(skin.name, "", runtime.scene);
+    //var importSkeleton = (runtime: IGLTFRuntime, skin: IGLTFSkin, newSkeleton: Skeleton, skinID: number): Skeleton => {
+    var importSkeleton = (runtime: IGLTFRuntime, skinNode: IGLTFNode, skin: IGLTFSkin): Skeleton => {
+        var name = skin.name || "skin" + skinNode.skin;
+
+        var babylonSkeleton = <Skeleton>skin.babylonSkeleton;
+        if (!babylonSkeleton) {
+            babylonSkeleton = new Skeleton(name, "skin" + skinNode.skin, runtime.babylonScene);
         }
 
         if (!skin.babylonSkeleton) {
-            return newSkeleton;
+            return babylonSkeleton;
         }
 
         // Matrices
-        var accessor = runtime.accessors[skin.inverseBindMatrices];
+        var accessor = runtime.gltf.accessors[skin.inverseBindMatrices];
         var buffer = GLTFUtils.GetBufferFromAccessor(runtime, accessor);
-
-        var bindShapeMatrix = Matrix.FromArray(skin.bindShapeMatrix);
 
         // Find the root bones
         var nodesToRoot: INodeToRoot[] = [];
         var nodesToRootToAdd: Bone[] = [];
 
-        getNodesToRoot(runtime, newSkeleton, skin, nodesToRoot);
-        newSkeleton.bones = [];
+        getNodesToRoot(runtime, babylonSkeleton, skin, nodesToRoot);
+        babylonSkeleton.bones = [];
 
         // Joints
-        for (var i = 0; i < skin.jointNames.length; i++) {
-            var jointNode = getJointNode(runtime, skin.jointNames[i]);
+        for (var i = 0; i < skin.joints.length; i++) {
+            var jointNode = getJointNode(runtime, skin.joints[i]);
             var node = jointNode.node;
 
             if (!node) {
-                Tools.Warn("Joint named " + skin.jointNames[i] + " does not exist");
+                Tools.Warn("Joint index " + skin.joints[i] + " does not exist");
                 continue;
             }
 
             var id = jointNode.id;
+            var stringID = "node" + id;
 
             // Optimize, if the bone already exists...
-            var existingBone = runtime.scene.getBoneByID(id);
+            var existingBone = runtime.babylonScene.getBoneByID(stringID);
             if (existingBone) {
-                newSkeleton.bones.push(existingBone);
+                babylonSkeleton.bones.push(existingBone);
                 continue;
             }
 
@@ -405,10 +387,10 @@ module BABYLON {
             var parentBone: Bone = null;
 
             for (var j = 0; j < i; j++) {
-                var joint: IGLTFNode = getJointNode(runtime, skin.jointNames[j]).node;
+                var joint: IGLTFNode = getJointNode(runtime, skin.joints[j]).node;
 
                 if (!joint) {
-                    Tools.Warn("Joint named " + skin.jointNames[j] + " does not exist when looking for parent");
+                    Tools.Warn("Joint index " + skin.joints[j] + " does not exist when looking for parent");
                     continue;
                 }
 
@@ -417,7 +399,7 @@ module BABYLON {
 
                 for (var k = 0; k < children.length; k++) {
                     if (children[k] === id) {
-                        parentBone = getParentBone(runtime, skin, skin.jointNames[j], newSkeleton);
+                        parentBone = getParentBone(runtime, skin, skin.joints[j], babylonSkeleton);
                         foundBone = true;
                         break;
                     }
@@ -441,38 +423,37 @@ module BABYLON {
                 }
             }
 
-            var bone = new Bone(node.jointName, newSkeleton, parentBone, mat);
-            bone.id = id;
+            var bone = new Bone(node.name || stringID, babylonSkeleton, parentBone, mat);
+            bone.id = stringID;
         }
 
         // Polish
-        var bones = newSkeleton.bones;
-        newSkeleton.bones = [];
+        var bones = babylonSkeleton.bones;
+        babylonSkeleton.bones = [];
         
-        for (var i = 0; i < skin.jointNames.length; i++) {
-            var jointNode: IJointNode = getJointNode(runtime, skin.jointNames[i]);
+        for (var i = 0; i < skin.joints.length; i++) {
+            var jointNode = getJointNode(runtime, skin.joints[i]);
 
             if (!jointNode) {
                 continue;
             }
 
             for (var j = 0; j < bones.length; j++) {
-                if (bones[j].id === jointNode.id) {
-                    newSkeleton.bones.push(bones[j]);
+                if (bones[j].id === "node" + jointNode.id) {
+                    babylonSkeleton.bones.push(bones[j]);
                     break;
                 }
             }
         }
 
-        newSkeleton.prepare();
+        babylonSkeleton.prepare();
 
         // Finish
         for (var i = 0; i < nodesToRootToAdd.length; i++) {
-            newSkeleton.bones.push(nodesToRootToAdd[i]);
+            babylonSkeleton.bones.push(nodesToRootToAdd[i]);
         }
 
-        return newSkeleton;
-        */
+        return babylonSkeleton;
     };
 
     /**
@@ -600,7 +581,7 @@ module BABYLON {
 
             // Sub material
             var material = undefined;
-            if (runtime.gltf.materials) {
+            if (runtime.gltf.materials && runtime.gltf.materials.length > 0) {
                 material = runtime.gltf.materials[primitive.material].babylonMaterial;
             }
             multiMat.subMaterials.push(material === undefined ? GLTFUtils.GetDefaultMaterial(runtime.babylonScene) : material);
@@ -667,7 +648,7 @@ module BABYLON {
     /**
     * Imports a node
     */
-    var importNode = (runtime: IGLTFRuntime, node: IGLTFNode, parent: Node): Node => {
+    var importNode = (runtime: IGLTFRuntime, node: IGLTFNode): Node => {
         var babylonNode: Mesh | TargetCamera = null;
 
         if (runtime.importOnlyMeshes && (node.skin !== undefined || node.mesh !== undefined)) {
@@ -678,25 +659,20 @@ module BABYLON {
 
         // Meshes
         if (node.skin !== undefined) {
-            // TODO: animation schema broken
-            /*
-            if (node.mesh) {
-                var skin: IGLTFSkin = runtime.gltf.skins[node.skin];
+            if (node.mesh !== undefined) {
+                var skin = runtime.gltf.skins[node.skin];
 
-                var newMesh = importMesh(runtime, node);
-                newMesh.skeleton = runtime.babylonScene.getLastSkeletonByID(node.skin);
+                var newMesh = importMesh(runtime, node, runtime.gltf.meshes[node.mesh]);
+                var newSkeleton = importSkeleton(runtime, node, skin);
 
-                if (newMesh.skeleton === null) {
-                    newMesh.skeleton = importSkeleton(runtime, skin, newMesh, skin.babylonSkeleton, node.skin);
-
-                    if (!skin.babylonSkeleton) {
-                        skin.babylonSkeleton = newMesh.skeleton;
-                    }
+                if (newSkeleton)
+                {
+                    newMesh.skeleton = newSkeleton;
+                    skin.babylonSkeleton = newSkeleton;
                 }
 
-                lastNode = newMesh;
+                babylonNode = newMesh;
             }
-            */
         }
         else if (node.mesh !== undefined) {
             babylonNode = importMesh(runtime, node, runtime.gltf.meshes[node.mesh]);
@@ -705,12 +681,11 @@ module BABYLON {
         else if (node.camera !== undefined && !node.babylonNode && !runtime.importOnlyMeshes) {
             var camera = runtime.gltf.cameras[node.camera];
 
-            if (camera) {
+            if (camera != undefined) {
                 if (camera.type === "orthographic") {
                     var orthographicCamera = camera.orthographic;
                     var orthoCamera = new FreeCamera(node.name || "camera" + node.camera, Vector3.Zero(), runtime.babylonScene);
 
-                    orthoCamera.name = node.name;
                     orthoCamera.mode = Camera.ORTHOGRAPHIC_CAMERA;
                     orthoCamera.attachControl(runtime.babylonScene.getEngine().getRenderingCanvas());
 
@@ -720,7 +695,6 @@ module BABYLON {
                     var perspectiveCamera = camera.perspective;
                     var persCamera = new FreeCamera(node.name || "camera" + node.camera, Vector3.Zero(), runtime.babylonScene);
 
-                    persCamera.name = node.name;
                     persCamera.attachControl(runtime.babylonScene.getEngine().getRenderingCanvas());
 
                     if (!perspectiveCamera.aspectRatio) {
@@ -738,16 +712,15 @@ module BABYLON {
         }
 
         // Empty node
-        if (node.jointName === undefined) {
-            if (node.babylonNode) {
-                return node.babylonNode;
-            }
-            else if (babylonNode === null) {
-                var dummy = new Mesh(node.name, runtime.babylonScene);
-                node.babylonNode = dummy;
-                babylonNode = dummy;
-            }
+        if (node.babylonNode) {
+            return node.babylonNode;
         }
+        else if (babylonNode === null) {
+            var dummy = new Mesh(node.name || "mesh" + node.mesh, runtime.babylonScene);
+            node.babylonNode = dummy;
+            babylonNode = dummy;
+        }
+        // end do this
 
         if (babylonNode !== null) {
             configureNode(babylonNode, node);
@@ -762,7 +735,7 @@ module BABYLON {
     * Traverses nodes and creates them
     */
     var traverseNodes = (runtime: IGLTFRuntime, index: number, parent: Node, meshIncluded?: boolean): void => {
-        var node: IGLTFNode = runtime.gltf.nodes[index];
+        var node = runtime.gltf.nodes[index];
         var newNode: Node = null;
 
         if (runtime.importOnlyMeshes && !meshIncluded) {
@@ -777,13 +750,15 @@ module BABYLON {
             meshIncluded = true;
         }
 
-        if (node.jointName === undefined && meshIncluded) {
-            newNode = importNode(runtime, node, parent);
+        if (meshIncluded) {
+            newNode = importNode(runtime, node);
 
             if (newNode !== null) {
+                newNode.id = "node" + index;
                 newNode.parent = parent;
             }
         }
+        // end do this
 
         if (node.children) {
             for (var i = 0; i < node.children.length; i++) {
@@ -1091,16 +1066,16 @@ module BABYLON {
             var skeletons = [];
 
             // Fill arrays of meshes and skeletons
-            for (var nde in runtime.gltf.nodes) {
-                var node: IGLTFNode = runtime.gltf.nodes[nde];
+            for (var i = 0; i < runtime.gltf.nodes.length; i++) {
+                var node = runtime.gltf.nodes[i];
 
                 if (node.babylonNode instanceof AbstractMesh) {
                     meshes.push(<AbstractMesh>node.babylonNode);
                 }
             }
 
-            for (var skl in runtime.gltf.skins) {
-                var skin: IGLTFSkin = runtime.gltf.skins[skl];
+            for (var i = 0; i < runtime.gltf.skins.length; i++) {
+                var skin = runtime.gltf.skins[i];
 
                 if (skin.babylonSkeleton instanceof Skeleton) {
                     skeletons.push(skin.babylonSkeleton);

--- a/loaders/src/glTF/babylon.glTFFileLoader.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoader.ts
@@ -44,7 +44,7 @@ module BABYLON {
 
         for (var animationIndex = 0; animationIndex < animations.length; animationIndex++) {
             var animation = animations[animationIndex];
-            if (!animation || !animation.channels) {
+            if (!animation || !animation.channels || !animation.samplers) {
                 continue;
             }
 
@@ -67,8 +67,8 @@ module BABYLON {
                 var bufferInput = GLTFUtils.GetBufferFromAccessor(runtime, runtime.gltf.accessors[inputData]);
                 var bufferOutput = GLTFUtils.GetBufferFromAccessor(runtime, runtime.gltf.accessors[outputData]);
 
-                var targetID = channel.target.id;
-                var targetNode: any = runtime.gltf.nodes[channel.target.id].babylonNode;
+                var targetID = channel.target.node;
+                var targetNode: any = runtime.gltf.nodes[channel.target.node].babylonNode;
                 if (targetNode === null) {
                     Tools.Warn("Creating animation index " + animationIndex + " but cannot find node index " + targetID + " to attach to");
                     continue;
@@ -599,7 +599,10 @@ module BABYLON {
             tempVertexData = undefined;
 
             // Sub material
-            var material = runtime.gltf.materials[primitive.material].babylonMaterial;
+            var material = undefined;
+            if (runtime.gltf.materials) {
+                material = runtime.gltf.materials[primitive.material].babylonMaterial;
+            }
             multiMat.subMaterials.push(material === undefined ? GLTFUtils.GetDefaultMaterial(runtime.babylonScene) : material);
 
             // Update vertices start and index start
@@ -822,8 +825,10 @@ module BABYLON {
     };
 
     var importMaterials = (runtime: IGLTFRuntime): void => {
-        for (var i = 0; i < runtime.gltf.materials.length; i++) {
-            GLTFFileLoaderExtension.LoadMaterial(runtime, i);
+        if (runtime.gltf.materials) {
+            for (var i = 0; i < runtime.gltf.materials.length; i++) {
+                GLTFFileLoaderExtension.LoadMaterial(runtime, i);
+            }
         }
     };
 

--- a/loaders/src/glTF/babylon.glTFFileLoaderInterfaces.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoaderInterfaces.ts
@@ -17,6 +17,12 @@ module BABYLON {
         FLOAT = 5126
     }
 
+    export enum EIndicesComponentType {
+        UNSIGNED_BYTE = 5121,
+        UNSIGNED_SHORT = 5123,
+        UNSIGNED_INT = 5125
+    }
+
     export enum EMeshPrimitiveMode {
         POINTS = 0,
         LINES = 1,
@@ -102,16 +108,33 @@ module BABYLON {
         name?: string;
     }
 
-    export interface IGLTFAccessor extends IGLTFChildRootProperty {
+    export interface IGLTFAccessorSparseIndices {
         bufferView: number;
-        byteOffset: number;
-        byteStride?: number;
+        byteOffset?: number;
+        componentType: EIndicesComponentType;
+    }
+
+    export interface IGLTFAccessorSparseValues {
+        bufferView: number;
+        byteOffset?: number;
+    }
+
+    export interface IGLTFAccessorSparse extends IGLTFProperty {
+        count: number;
+        indices: IGLTFAccessorSparseIndices;
+        values: IGLTFAccessorSparseValues;
+    }
+
+    export interface IGLTFAccessor extends IGLTFChildRootProperty {
+        bufferView?: number;
+        byteOffset?: number;
         componentType: EComponentType;
         normalized?: boolean;
         count: number;
         type: string;
         max: number[];
         min: number[];
+        sparse?: IGLTFAccessorSparse;
     }
 
     export interface IGLTFAnimationChannel {
@@ -159,6 +182,7 @@ module BABYLON {
         buffer: number;
         byteOffset: number;
         byteLength: number;
+        byteStride?: number;
         target?: EBufferViewTarget;
     }
 
@@ -222,23 +246,24 @@ module BABYLON {
         indices?: number;
         material?: number;
         mode?: EMeshPrimitiveMode;
+        targets?: number[];
     }
 
     export interface IGLTFMesh extends IGLTFChildRootProperty {
         primitives: IGLTFMeshPrimitive[];
+        weights?: number[];
     }
 
     export interface IGLTFNode extends IGLTFChildRootProperty {
         camera?: number;
         children?: number[];
-        skeletons?: number[];
         skin?: number;
-        jointName?: number;
-        matrix: number[];
+        matrix?: number[];
         mesh?: number;
         rotation?: number[];
         scale?: number[];
         translation?: number[];
+        weights?: number[];
 
         // Babylon.js values (optimize)
         babylonNode?: Node;
@@ -256,10 +281,11 @@ module BABYLON {
     }
 
     export interface IGLTFSkin extends IGLTFChildRootProperty {
-        bindShapeMatrix?: number[];
         inverseBindMatrices?: number;
-        jointNames: number[];
+        skeleton?: number;
+        joints: number[];
 
+        // Babylon.js values (optimize)
         babylonSkeleton?: Skeleton;
     }
 
@@ -319,11 +345,11 @@ module BABYLON {
     export interface INodeToRoot {
         bone: Bone;
         node: IGLTFNode;
-        id: string;
+        id: number;
     }
 
     export interface IJointNode {
         node: IGLTFNode;
-        id: string;
+        id: number;
     }
 }

--- a/loaders/src/glTF/babylon.glTFFileLoaderInterfaces.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoaderInterfaces.ts
@@ -120,7 +120,7 @@ module BABYLON {
     }
 
     export interface IGLTFAnimationChannelTarget {
-        id: number;
+        node: number;
         path: string;
     }
 
@@ -131,8 +131,8 @@ module BABYLON {
     }
 
     export interface IGLTFAnimation extends IGLTFChildRootProperty {
-        channels?: IGLTFAnimationChannel[];
-        samplers?: IGLTFAnimationSampler[];
+        channels: IGLTFAnimationChannel[];
+        samplers: IGLTFAnimationSampler[];
     }
 
     export interface IGLTFAssetProfile extends IGLTFProperty {

--- a/loaders/src/glTF/babylon.glTFFileLoaderInterfaces.ts
+++ b/loaders/src/glTF/babylon.glTFFileLoaderInterfaces.ts
@@ -17,12 +17,6 @@ module BABYLON {
         FLOAT = 5126
     }
 
-    export enum EIndicesComponentType {
-        UNSIGNED_BYTE = 5121,
-        UNSIGNED_SHORT = 5123,
-        UNSIGNED_INT = 5125
-    }
-
     export enum EMeshPrimitiveMode {
         POINTS = 0,
         LINES = 1,
@@ -108,13 +102,13 @@ module BABYLON {
         name?: string;
     }
 
-    export interface IGLTFAccessorSparseIndices {
+    export interface IGLTFAccessorSparseIndices extends IGLTFProperty {
         bufferView: number;
         byteOffset?: number;
-        componentType: EIndicesComponentType;
+        componentType: EComponentType;
     }
 
-    export interface IGLTFAccessorSparseValues {
+    export interface IGLTFAccessorSparseValues extends IGLTFProperty {
         bufferView: number;
         byteOffset?: number;
     }
@@ -137,17 +131,17 @@ module BABYLON {
         sparse?: IGLTFAccessorSparse;
     }
 
-    export interface IGLTFAnimationChannel {
+    export interface IGLTFAnimationChannel extends IGLTFProperty {
         sampler: number;
         target: IGLTFAnimationChannelTarget;
     }
 
-    export interface IGLTFAnimationChannelTarget {
+    export interface IGLTFAnimationChannelTarget extends IGLTFProperty {
         node: number;
         path: string;
     }
 
-    export interface IGLTFAnimationSampler {
+    export interface IGLTFAnimationSampler extends IGLTFProperty {
         input: number;
         interpolation?: string;
         output: number;
@@ -186,14 +180,14 @@ module BABYLON {
         target?: EBufferViewTarget;
     }
 
-    export interface IGLTFCameraOrthographic {
+    export interface IGLTFCameraOrthographic extends IGLTFProperty {
         xmag: number;
         ymag: number;
         zfar: number;
         znear: number;
     }
 
-    export interface IGLTFCameraPerspective {
+    export interface IGLTFCameraPerspective extends IGLTFProperty {
         aspectRatio: number;
         yfov: number;
         zfar: number;
@@ -345,11 +339,11 @@ module BABYLON {
     export interface INodeToRoot {
         bone: Bone;
         node: IGLTFNode;
-        id: number;
+        index: number;
     }
 
     export interface IJointNode {
         node: IGLTFNode;
-        id: number;
+        index: number;
     }
 }


### PR DESCRIPTION
This series of changes updates ImportSkeleton and supporting methods to handle 2.0 animations. Additionally, it normalizes the node id scheme so nodes can be searched for.